### PR TITLE
Added workaround for CloudCustodian resource destruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,5 @@ deploy:
 	c7n-org run -c generated/custodian/generated_custodian_config.json -u generated/custodian/generated_custodian_policy.json --output-dir s3://$$S3_STATE_BUCKET/$$CUSTODIAN_PREFIX
 
 destroy:
-	if [ -f generated/custodian/generated_custodian_config.json ] && [ -f generated/custodian/generated_custodian_policy.json ] ; \
-	then \
-	  	source deployment_variables.env && \
-		c7n-org run-script --output-dir s3://$$S3_STATE_BUCKET/$$CUSTODIAN_PREFIX -c generated/custodian/generated_custodian_config.json "python3 utils/mugc.py --present -c generated/custodian/generated_custodian_policy.json"; \
-	fi;
+	bash destroyCloudCustodianResources.sh
 	cd generated/terraform/ && terraform destroy

--- a/destroyCloudCustodianResources.sh
+++ b/destroyCloudCustodianResources.sh
@@ -6,5 +6,5 @@ rolesArray=(${ROLES})
 for (( i=0; i<${#accountsArray[@]}; i++));
   do
     echo "Destroying CloudCustodian resources on ${accountsArray[$i]}"
-		c7n-org run-script --output-dir s3://$S3_STATE_BUCKET/$CUSTODIAN_PREFIX -c generated/custodian/generated_custodian_config.json -a ${accountsArray[$i]} "python3 utils/mugc.py --assume ${rolesArray[$i]} --present -c generated/custodian/generated_custodian_policy.json"
+    c7n-org run-script --output-dir s3://$S3_STATE_BUCKET/$CUSTODIAN_PREFIX -c generated/custodian/generated_custodian_config.json -a ${accountsArray[$i]} "python3 utils/mugc.py --assume ${rolesArray[$i]} --present -c generated/custodian/generated_custodian_policy.json"
   done

--- a/destroyCloudCustodianResources.sh
+++ b/destroyCloudCustodianResources.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source deployment_variables.env
+accountsArray=(${ACCOUNTS})
+rolesArray=(${ROLES})
+for (( i=0; i<${#accountsArray[@]}; i++));
+  do
+    echo "Destroying CloudCustodian resources on ${accountsArray[$i]}"
+		c7n-org run-script --output-dir s3://$S3_STATE_BUCKET/$CUSTODIAN_PREFIX -c generated/custodian/generated_custodian_config.json -a ${accountsArray[$i]} "python3 utils/mugc.py --assume ${rolesArray[$i]} --present -c generated/custodian/generated_custodian_policy.json"
+  done


### PR DESCRIPTION
#19 

Uses env variables created during file generation to specify the account and role for Cloud Custodian resource destruction. This isn't ideal, but the CC mugc.py has some shortcomings that haven't been addressed.