### PR TITLE
CloudCustodian policy now filters by regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ c7n==0.9.8
 c7n-mailer==0.6.7
 PyYAML==5.3.1
 c7n-org==0.6.9
+pytest==6.2.3

--- a/templates/policy_template.py
+++ b/templates/policy_template.py
@@ -1,5 +1,5 @@
 from typing import Mapping
-from utils.helpers import create_config_policy_resource_name
+from utils.helpers import create_config_policy_resource_name, owner_tag_email_regex, owner_tag_shared_regex
 
 
 def custodian_policy_template(config: Mapping) -> Mapping:
@@ -22,13 +22,13 @@ def custodian_policy_template(config: Mapping) -> Mapping:
                                 "type": "value",
                                 "key": "tag:Owner",
                                 "op": "regex",
-                                "value": "^((?!(@.*\\.)).)*$"
+                                "value": owner_tag_email_regex()
                             },
                             {  # Case insensitive match of 'shared' in the owner tag
                                 "type": "value",
                                 "key": "tag:Owner",
                                 "op": "regex",
-                                "value": "(?i)^((?!shared).)*$"
+                                "value": owner_tag_shared_regex()
                             }]
                         }
                     ]},

--- a/templates/policy_template.py
+++ b/templates/policy_template.py
@@ -11,9 +11,28 @@ def custodian_policy_template(config: Mapping) -> Mapping:
                     "type": "config-rule"
                 },
                 "resource": resource,
-                "filters": [{
-                    "tag:Owner": "absent"
-                }]
+                "filters": [
+                    # Owner tag [is absent] or [does not look like an email address AND does not have the word 'shared' (case insensitive)]
+                    {"or": [
+                        {
+                            "tag:Owner": "absent"
+                        },
+                        {"and": [
+                            {  # The general sequence '{content}@{content}.{content}' is not followed in the owner tag
+                                "type": "value",
+                                "key": "tag:Owner",
+                                "op": "regex",
+                                "value": "^((?!(@.*\\.)).)*$"
+                            },
+                            {  # Case insensitive match of 'shared' in the owner tag
+                                "type": "value",
+                                "key": "tag:Owner",
+                                "op": "regex",
+                                "value": "(?i)^((?!shared).)*$"
+                            }]
+                        }
+                    ]},
+                ]
             } for resource in config["aws"]["resources"]
         ]
     }

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,46 @@
+from utils.helpers import owner_tag_email_regex, owner_tag_shared_regex
+import re
+
+
+def test_email_regex_no_match():
+
+    # These are all 'valid' emails, so they shouldn't match
+    assert not re.match(owner_tag_email_regex(), "somethingthinething@abc.com")
+    assert not re.match(owner_tag_email_regex(), "a@b.c")
+    assert not re.match(owner_tag_email_regex(), "@@@...")
+    assert not re.match(owner_tag_email_regex(), "standard@@gmail..com")
+    assert not re.match(owner_tag_email_regex(), "@.")
+
+
+def test_email_regex_match():
+
+    # These are all 'invalid' emails, so they should match
+    assert re.match(owner_tag_email_regex(), "abc")
+    assert re.match(owner_tag_email_regex(), "")
+    assert re.match(owner_tag_email_regex(), "bob@gmailcom")
+    assert re.match(owner_tag_email_regex(), "bobgmail.com")
+    assert re.match(owner_tag_email_regex(), "@@@@@")
+    assert re.match(owner_tag_email_regex(), ".@")
+
+
+def test_shared_regex_no_match():
+
+    # These all include 'shared', so they shouldn't match
+    assert not re.match(owner_tag_shared_regex(), "shared")
+    assert not re.match(owner_tag_shared_regex(), "Shared")
+    assert not re.match(owner_tag_shared_regex(), "ShARed")
+    assert not re.match(owner_tag_shared_regex(), "xyzsharedabc")
+    assert not re.match(owner_tag_shared_regex(), "please-dont-delete-me-im-a-SHARED-resource")
+    assert not re.match(owner_tag_shared_regex(), "shashashashared")
+    assert not re.match(owner_tag_shared_regex(), "shared-ish")
+
+
+def test_shared_regex_match():
+
+    # These all don't include 'shared', so they should match
+    assert re.match(owner_tag_shared_regex(), "share")
+    assert re.match(owner_tag_shared_regex(), "shree")
+    assert re.match(owner_tag_shared_regex(), "spellingshrared")
+    assert re.match(owner_tag_shared_regex(), "s h a r e d")
+    assert re.match(owner_tag_shared_regex(), "email@share.d")
+    assert re.match(owner_tag_shared_regex(), "")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -18,3 +18,11 @@ def create_config_policy_resource_name(policy_prefix: str, resource_type:str) ->
 # Custodian prepends a prefix to resources.
 def create_deployed_config_policy_resource_name(policy_prefix: str, resource_type:str) -> str:
     return "custodian-" + create_config_policy_resource_name(policy_prefix, resource_type)
+
+
+def owner_tag_email_regex() -> str:
+    return "^((?!(@.*\\.)).)*$"
+
+
+def owner_tag_shared_regex() -> str:
+    return "(?i)^((?!shared).)*$"


### PR DESCRIPTION
The CloudCustodian policy should mark resources as `NONCOMPLIANT` if the following statement evaluates to `true`:

`(Owner tag is absent) OR (Owner tag doesn't look like an email AND Owner tag doesn't contain the string 'shared')`

The regex for not being an email look-alike:
`^((?!(@.*\\.)).)*$`

The regex for not containing the string 'shared' (case insensitive):
`(?i)^((?!shared).)*$`

Any S3 bucket that matches the filter will be at the mercy of any actions associated with the CloudCustodian policy (most likely resource deletion). Just to be safe, a second set of eyes on the regex would be much appreciated to make sure there are no edge cases.