### PR TITLE
Both Owner and owner are acceptable tags for the filtering policy

### DIFF
--- a/templates/policy_template.py
+++ b/templates/policy_template.py
@@ -1,5 +1,5 @@
 from typing import Mapping
-from utils.helpers import create_config_policy_resource_name, owner_tag_email_regex, owner_tag_shared_regex
+from utils.helpers import create_config_policy_resource_name, custodian_config_policy_dict
 
 
 def custodian_policy_template(config: Mapping) -> Mapping:
@@ -11,27 +11,12 @@ def custodian_policy_template(config: Mapping) -> Mapping:
                     "type": "config-rule"
                 },
                 "resource": resource,
-                "filters": [
-                    # Owner tag [is absent] or [does not look like an email address AND does not have the word 'shared' (case insensitive)]
-                    {"or": [
-                        {
-                            "tag:Owner": "absent"
-                        },
-                        {"and": [
-                            {  # The general sequence '{content}@{content}.{content}' is not followed in the owner tag
-                                "type": "value",
-                                "key": "tag:Owner",
-                                "op": "regex",
-                                "value": owner_tag_email_regex()
-                            },
-                            {  # Case insensitive match of 'shared' in the owner tag
-                                "type": "value",
-                                "key": "tag:Owner",
-                                "op": "regex",
-                                "value": owner_tag_shared_regex()
-                            }]
-                        }
-                    ]},
+                "filters": [{"and": [
+                    # Owner/owner tag [is absent] or [does not look like an email address AND does not have the word 'shared' (case
+                    # insensitive)]
+                    custodian_config_policy_dict("Owner"),
+                    custodian_config_policy_dict("owner")
+                ]}
                 ]
             } for resource in config["aws"]["resources"]
         ]

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,9 +1,11 @@
+from typing import Mapping
+
 
 def create_role_string(account_id: str, iam_role_name: str) -> str:
     return "arn:aws:iam::" + account_id + ":role/" + iam_role_name
 
 
-def create_full_iam_resource_name(iam_resource_prefix: str, account_name:str) -> str:
+def create_full_iam_resource_name(iam_resource_prefix: str, account_name: str) -> str:
     return iam_resource_prefix + account_name
 
 
@@ -11,12 +13,12 @@ def create_remote_bucket_string(remote_bucket_name: str) -> str:
     return "arn:aws:s3:::" + remote_bucket_name + "/*"
 
 
-def create_config_policy_resource_name(policy_prefix: str, resource_type:str) -> str:
+def create_config_policy_resource_name(policy_prefix: str, resource_type: str) -> str:
     return policy_prefix + resource_type
 
 
 # Custodian prepends a prefix to resources.
-def create_deployed_config_policy_resource_name(policy_prefix: str, resource_type:str) -> str:
+def create_deployed_config_policy_resource_name(policy_prefix: str, resource_type: str) -> str:
     return "custodian-" + create_config_policy_resource_name(policy_prefix, resource_type)
 
 
@@ -26,3 +28,27 @@ def owner_tag_email_regex() -> str:
 
 def owner_tag_shared_regex() -> str:
     return "(?i)^((?!shared).)*$"
+
+
+# Because we are duplicating the filtering logic, keep it in a function.
+# The specified 'desired_tag' parameter will be the resource tag that we are viewing for compliance.
+def custodian_config_policy_dict(desired_tag: str) -> Mapping:
+    return {"or": [
+        {
+            f"tag:{desired_tag}": "absent"
+        },
+        {"and": [
+            {  # The general sequence '{content}@{content}.{content}' is not followed in the owner tag
+                "type": "value",
+                "key": f"tag:{desired_tag}",
+                "op": "regex",
+                "value": owner_tag_email_regex()
+            },
+            {  # Case insensitive match of 'shared' in the owner tag
+                "type": "value",
+                "key": f"tag:{desired_tag}",
+                "op": "regex",
+                "value": owner_tag_shared_regex()
+            }]
+        }
+    ]}


### PR DESCRIPTION
The policy now filters against both `Owner` and `owner`. If either are compliant, the resource is marked `COMPLIANT`

Addresses: https://github.com/ucsc-cgp/cgp-cloud-policies/issues/30