### PR TITLE
Lambda polling policies instead of config

### DIFF
--- a/templates/policy_template.py
+++ b/templates/policy_template.py
@@ -22,7 +22,7 @@ def custodian_compliance_policy(config: Mapping, resource: str) -> Mapping:
         "description": "This policy will mark improperly tagged resources for deletion.",
         "mode": {
             "type": "periodic",
-            "schedule": "rate(15 minutes)"
+            "schedule": "rate(1 hour)"
         },
         "resource": resource,
         "filters": [{"and": [


### PR DESCRIPTION
This switches away from using config policies in favor of polling with lambdas. This is specifically to reduce costs for some of the more 'resource creation aggressive' accounts (mainly those that create lots for testing).